### PR TITLE
Upgrade Travis CI dist to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ---
 sudo: false
 
+dist: xenial
+
 language: ruby
 
 rvm:
@@ -17,7 +19,7 @@ cache:
   bundler: true
 
 before_install:
-  - gem install bundler -v 1.17.1
+  - gem install bundler
 
 script:
   - bundle install


### PR DESCRIPTION
This new Linux distro for Travis includes the latest Ruby 2.4 and 2.5 versions.

Trying it (will be stable in january) to check build time that we might use for our private projects too.