### PR TITLE
Adapt FuelSurcharge::TNT to TNT's website changes 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+# hcs/Makefile
+
+# Don't forget : Makefiles use tabs indentation, not spaces !
+.PHONY: test watch
+
+# Aliases to everyday takss faster
+t  : test
+w  : watch
+
+test: ## Run all tests
+	@rake test
+
+watch: ## Run tests when a file changes (like Guard)
+	@ls **/*_test.rb | entr rake test

--- a/lib/fuel_surcharge/tnt.rb
+++ b/lib/fuel_surcharge/tnt.rb
@@ -19,21 +19,15 @@ module FuelSurcharge
     end
 
     def time_period
-      return unless @road_values
-
-      @road_values.first.to_s.strip
+      @road_values&.first&.to_s
     end
 
     def road_percentage
-      return unless @road_values
-
-      @road_values.last.to_s
+      @road_values&.last&.to_s
     end
 
     def air_percentage
-      return unless @air_values
-
-      @air_values.last.to_s
+      @air_values&.last&.to_s
     end
 
     def road_multiplier

--- a/lib/fuel_surcharge/tnt.rb
+++ b/lib/fuel_surcharge/tnt.rb
@@ -6,9 +6,12 @@ require "fuel_surcharge/string_formatter"
 module FuelSurcharge
   class TNT
     using StringFormatter
+
     def initialize
-      @road_values = extracted_values.first
-      @air_values  = extracted_values.last(3).first
+      latest_road_values_position = 0
+      latest_air_values_position = extracted_values.size.div(2)
+      @road_values = extracted_values[latest_road_values_position]
+      @air_values  = extracted_values[latest_air_values_position]
     end
 
     def url
@@ -43,6 +46,7 @@ module FuelSurcharge
 
     private
 
+    VALUES_REGEX = /Surcharge d[e\' ]+(.*) : (.*%)</.freeze
     # [
     #   [" novembre 2018 ",  "12,10%"],
     #   ["octobre 2018 ",    "11,95%"],
@@ -52,11 +56,11 @@ module FuelSurcharge
     #   [" septembre 2018 ", "17,50%"]
     # ]
     def extracted_values
-      @extracted_values ||=
-        HTTPRequest.new(url)
-                   .response
-                   .to_s
-                   .scan(/Surcharge d[e']+(.*): (.*)<br>$/)
+      @extracted_values ||= response.to_s.scan(VALUES_REGEX)
+    end
+
+    def response
+      @response ||= HTTPRequest.new(url).response
     end
   end
 end

--- a/lib/fuel_surcharge/tnt.rb
+++ b/lib/fuel_surcharge/tnt.rb
@@ -4,7 +4,7 @@ require "fuel_surcharge/http_request"
 require "fuel_surcharge/string_formatter"
 
 module FuelSurcharge
-  class Tnt
+  class TNT
     using StringFormatter
     def initialize
       @road_values = extracted_values.first

--- a/test/fuel_surcharge/tnt_test.rb
+++ b/test/fuel_surcharge/tnt_test.rb
@@ -38,24 +38,29 @@ module FuelSurcharge
       end
     end
 
+    FRENCH_MONTHS = %w[janvier février mars avril mai juin juillet août
+                       septembre octobre novembre décembre].freeze
+
     def test_live_values
       skip if ENV["SKIP_LIVE_TESTS"]
 
-      live_tnt  = Tnt.new
-      live_date = Date.parse live_tnt.time_period
+      @tnt = TNT.new
+      time_period = @tnt.time_period
 
-      assert_equal Date.today.month, live_date.month
-      assert_equal Date.today.year,  live_date.year
+      assert_kind_of String, time_period.downcase
 
-      assert_kind_of String,     live_tnt.air_percentage
-      refute_empty               live_tnt.air_percentage
-      assert_kind_of BigDecimal, live_tnt.air_multiplier
-      assert_operator live_tnt.air_multiplier, :>=, 1.0
+      assert time_period.start_with?(FRENCH_MONTHS[Date.today.month])
+      assert time_period.end_with?(Date.today.year.to_s)
 
-      assert_kind_of String,     live_tnt.road_percentage
-      refute_empty               live_tnt.road_percentage
-      assert_kind_of BigDecimal, live_tnt.road_multiplier
-      assert_operator live_tnt.road_multiplier, :>=, 1.0
+      assert_kind_of String,     @tnt.air_percentage
+      refute_empty               @tnt.air_percentage
+      assert_kind_of BigDecimal, @tnt.air_multiplier
+      assert_operator @tnt.air_multiplier, :>=, 1.0
+
+      assert_kind_of String,     @tnt.road_percentage
+      refute_empty               @tnt.road_percentage
+      assert_kind_of BigDecimal, @tnt.road_multiplier
+      assert_operator @tnt.road_multiplier, :>=, 1.0
     end
 
     private

--- a/test/fuel_surcharge/tnt_test.rb
+++ b/test/fuel_surcharge/tnt_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 module FuelSurcharge
-  class TnTTest < Minitest::Test
+  class TNTTest < Minitest::Test
     def test_time_period
       nominal_case do
         assert_equal "novembre 2018", @tnt.time_period
@@ -63,14 +63,14 @@ module FuelSurcharge
     def nominal_case
       sample_response = File.read("test/fixtures/tnt_sample_response.html")
       HTTPRequest.stub_any_instance :response, sample_response do
-        @tnt = Tnt.new
+        @tnt = TNT.new
         yield
       end
     end
 
     def failing_case
       HTTPRequest.stub_any_instance :response, "" do
-        @tnt = Tnt.new
+        @tnt = TNT.new
         yield
       end
     end


### PR DESCRIPTION
Handles "décembre" as the month name via more reliable tests.