### PR TITLE
Generate changelog with github_changelog_generator gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## [Unreleased](https://github.com/levups/fuel_surcharge/tree/HEAD)
+
+[Full Changelog](https://github.com/levups/fuel_surcharge/compare/v0.1.0...HEAD)
+
+**Implemented enhancements:**
+
+- Rename Tnt class to TNT [\#5](https://github.com/levups/fuel_surcharge/issues/5)
+
+**Merged pull requests:**
+
+- Adapt FuelSurcharge::TNT to TNT's website changes  [\#3](https://github.com/levups/fuel_surcharge/pull/3) ([czj](https://github.com/czj))
+- Upgrade Travis CI dist to Xenial [\#2](https://github.com/levups/fuel_surcharge/pull/2) ([czj](https://github.com/czj))
+
 ## [v0.1.0](https://github.com/levups/fuel_surcharge/tree/v0.1.0) (2018-11-25)
 **Merged pull requests:**
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,28 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    concurrent-ruby (1.1.3)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    faraday-http-cache (2.0.0)
+      faraday (~> 0.8)
+    github_changelog_generator (1.14.3)
+      activesupport
+      faraday-http-cache
+      multi_json
+      octokit (~> 4.6)
+      rainbow (>= 2.1)
+      rake (>= 10.0)
+      retriable (~> 2.1)
     http (4.0.0)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -20,10 +38,24 @@ GEM
       domain_name (~> 0.5)
     http-form_data (2.1.1)
     http_parser.rb (0.6.0)
+    i18n (1.1.1)
+      concurrent-ruby (~> 1.0)
     minitest (5.11.3)
     minitest-stub_any_instance (1.0.2)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    octokit (4.13.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
     public_suffix (3.0.3)
+    rainbow (3.0.0)
     rake (10.5.0)
+    retriable (2.1.0)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
@@ -34,6 +66,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.17)
   fuel_surcharge!
+  github_changelog_generator (~> 1.14)
   minitest (~> 5.0)
   minitest-stub_any_instance (~> 1.0)
   rake (~> 10.0)

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,17 @@
 require "bundler/gem_tasks"
+require "github_changelog_generator/task"
 require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]
+end
+
+GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+  config.user                 = "levups"
+  config.project              = "fuel_surcharge"
+  config.add_issues_wo_labels = false
 end
 
 task default: :test

--- a/fuel_surcharge.gemspec
+++ b/fuel_surcharge.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "http", "~> 4.0"
 
   spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "github_changelog_generator", "~> 1.14"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "minitest-stub_any_instance", "~> 1.0"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
github_changelog_generator relies on opened/closes issues, and merged PR to generate the changelog.

use the rake task `rake changelog` to generate changes and make a commit.
