### PR TITLE
Add BigDecimal compatibility for ruby 2.6

### DIFF
--- a/lib/fuel_surcharge/string_formatter.rb
+++ b/lib/fuel_surcharge/string_formatter.rb
@@ -6,7 +6,7 @@ module FuelSurcharge
   module StringFormatter
     refine String do
       def to_multiplier
-        number = BigDecimal tr(",", ".")
+        number = BigDecimal tr(",", ".").gsub(/[^0-9\.]/, "")
 
         (number / 100 + 1).round(4)
       end


### PR DESCRIPTION
Filter string to pass on to Bigdecimal in to_multiplier method to
prevent errors like:

```
ArgumentError: invalid value for BigDecimal()
```